### PR TITLE
Fix console appender

### DIFF
--- a/src/main/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderFactory.java
+++ b/src/main/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderFactory.java
@@ -25,6 +25,7 @@ public class LogstashConsoleAppenderFactory extends ConsoleAppenderFactory {
 
         Encoder<ILoggingEvent> encoder = new LogstashEncoder();
         encoder.setContext(context);
+        encoder.start();
 
         final ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<>();
         appender.setName("logstash-console-appender");


### PR DESCRIPTION
This previously failed to log anything to the console as
`LogstashEncoder` hadn't been started.