### PR TITLE
Update dependencies to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,12 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard: '1.0.5'
+        dropwizard: '1.1.0'
 ]
 
 dependencies {
     compile "io.dropwizard:dropwizard-core:$dependencyVersions.dropwizard",
-            'net.logstash.logback:logstash-logback-encoder:4.8'
+            'net.logstash.logback:logstash-logback-encoder:4.9'
 
     testCompile 'junit:junit:4.11',
             'org.hamcrest:hamcrest-library:1.3',


### PR DESCRIPTION
These updates are required in order to not have
`java.lang.AbstractMethodError` with the latest versions (1.1.0) of
DropWizard.