### PR TITLE
Standardize field names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: java
+cache:
+  directories:
+  - $HOME/.gradle/caches
+  - $HOME/.gradle/wrapper
+  - $HOME/.m2
 jdk:
 - oraclejdk8
 after_success:

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,25 @@ dependencies {
             "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizard"
 }
 
+test {
+    testLogging {
+        events "skipped", "failed", "standardError"
+        showCauses true
+        showExceptions true
+        showStackTraces true
+        exceptionFormat "full"
+
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+            }
+        }
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/src/main/java/uk/gov/ida/dropwizard/logstash/AccessLogstashConsoleAppenderFactory.java
+++ b/src/main/java/uk/gov/ida/dropwizard/logstash/AccessLogstashConsoleAppenderFactory.java
@@ -4,35 +4,37 @@ import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.spi.ContextAware;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.JsonGenerator;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.async.AsyncAppenderFactory;
 import io.dropwizard.logging.filter.LevelFilterFactory;
 import io.dropwizard.logging.layout.LayoutFactory;
-import net.logstash.logback.composite.loggingevent.MessageJsonProvider;
-import net.logstash.logback.encoder.LogstashAccessEncoder;
-import net.logstash.logback.fieldnames.LogstashAccessFieldNames;
+import net.logstash.logback.composite.AbstractJsonProvider;
+import net.logstash.logback.composite.AbstractNestedJsonProvider;
+import net.logstash.logback.composite.CompositeJsonFormatter;
+import net.logstash.logback.composite.JsonProvider;
+import net.logstash.logback.composite.JsonProviders;
+import net.logstash.logback.composite.LogstashVersionJsonProvider;
+import net.logstash.logback.composite.accessevent.AccessEventCompositeJsonFormatter;
+import net.logstash.logback.composite.accessevent.AccessEventFormattedTimestampJsonProvider;
+import net.logstash.logback.composite.accessevent.AccessMessageJsonProvider;
+import net.logstash.logback.composite.accessevent.MethodJsonProvider;
+import net.logstash.logback.composite.accessevent.RemoteUserJsonProvider;
+import net.logstash.logback.composite.accessevent.StatusCodeJsonProvider;
+import net.logstash.logback.encoder.AccessEventCompositeJsonEncoder;
+import uk.gov.ida.dropwizard.logstash.typed.BytesField;
+import uk.gov.ida.dropwizard.logstash.typed.MillisecondsField;
 
+import java.io.IOException;
+
+/**
+ * Resets the field names to be modern (post-2013) logstash style
+ * @see <a href="https://logstash.jira.com/browse/LOGSTASH-675">the logstash issue changing the name scheme</a>
+ */
 @JsonTypeName("access-logstash-console")
 public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory<IAccessEvent> {
-    /**
-     * Resets the field names to be modern (post-2013) logstash style
-     * @see <a href="https://logstash.jira.com/browse/LOGSTASH-675">the logstash issue changing the name scheme</a>
-     */
-    private static final LogstashAccessFieldNames logstash675FieldNames = new LogstashAccessFieldNames() {{
-        setFieldsContentLength("content_length");
-        setFieldsElapsedTime("elapsed_time");
-        setFieldsHostname("hostname");
-        setFieldsMethod("method");
-        setFieldsProtocol("protocol");
-        setFieldsRemoteHost("remote_host");
-        setFieldsRemoteUser("remote_user");
-        setFieldsRequestedUri("requested_uri");
-        setFieldsRequestedUrl(null); // duplicates requested_uri, method, protocol
-        setFieldsStatusCode("status_code");
-        setMessage(MessageJsonProvider.FIELD_MESSAGE);
-    }};
-
     @Override
     public Appender<IAccessEvent> build(LoggerContext context,
                                          String applicationName,
@@ -40,8 +42,12 @@ public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory
                                          LevelFilterFactory<IAccessEvent> levelFilterFactory,
                                          AsyncAppenderFactory<IAccessEvent> asyncAppenderFactory) {
 
-        LogstashAccessEncoder encoder = new LogstashAccessEncoder();
-        encoder.setFieldNames(logstash675FieldNames);
+        AccessEventCompositeJsonEncoder encoder = new AccessEventCompositeJsonEncoder() {
+            @Override
+            protected CompositeJsonFormatter<IAccessEvent> createFormatter() {
+                return new CustomFormatter(this);
+            }
+        };
         encoder.setContext(context);
         encoder.start();
 
@@ -53,5 +59,80 @@ public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory
         appender.start();
 
         return wrapAsync(appender, asyncAppenderFactory);
+    }
+
+    private class CustomFormatter extends AccessEventCompositeJsonFormatter {
+        public CustomFormatter(ContextAware declaredOrigin) {
+            super(declaredOrigin);
+
+            JsonProviders<IAccessEvent> topLevel = getProviders();
+            topLevel.addProvider(new AccessEventFormattedTimestampJsonProvider());
+            topLevel.addProvider(new LogstashVersionJsonProvider<>());
+            topLevel.addProvider(new AccessMessageJsonProvider() {{setFieldName("message");}});
+            topLevel.addProvider(accessProvider());
+        }
+
+        private JsonProvider<IAccessEvent> accessProvider() {
+            AbstractNestedJsonProvider<IAccessEvent> access = new AbstractNestedJsonProvider<IAccessEvent>() {};
+            access.setFieldName("access");
+            JsonProviders<IAccessEvent> accessProviders = access.getProviders();
+            accessProviders.addProvider(new MethodJsonProvider() {{setFieldName("method");}});
+            accessProviders.addProvider(new HttpVersionJsonProvider());
+            accessProviders.addProvider(new StatusCodeJsonProvider() {{setFieldName("response_code");}});
+            accessProviders.addProvider(new UrlJsonProvider());
+            accessProviders.addProvider(new RemoteIpJsonProvider());
+            accessProviders.addProvider(new RemoteUserJsonProvider() {{setFieldName("user_name");}});
+            accessProviders.addProvider(new BodySentJsonProvider());
+            accessProviders.addProvider(new ElapsedTimeMsJsonProvider());
+            return access;
+        }
+    }
+
+    public static class ElapsedTimeMsJsonProvider extends AbstractJsonProvider<IAccessEvent> {
+        @Override
+        public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
+            generator.writeObjectField("elapsed_time", new MillisecondsField(event.getElapsedTime()));
+        }
+    }
+
+    public static class BodySentJsonProvider extends AbstractJsonProvider<IAccessEvent> {
+        @Override
+        public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
+            generator.writeObjectField("body_sent", new BytesField(event.getContentLength()));
+        }
+    }
+
+    /**
+     * Provides http_version without leading "HTTP/", for consistency with filebeat apache2/nginx modules
+     */
+    public static class HttpVersionJsonProvider extends AbstractJsonProvider<IAccessEvent> {
+        @Override
+        public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
+            generator.writeStringField("http_version", event.getProtocol().replace("HTTP/",""));
+        }
+    }
+
+    public static class UrlJsonProvider extends AbstractJsonProvider<IAccessEvent> {
+        @Override
+        public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
+            String firstLineWithoutMethod = firstLineOfRequest(event).replaceFirst("^[A-Z]* ", "");
+            String requestedUrl = firstLineWithoutMethod.replaceFirst(" HTTP/.*$", "");
+            generator.writeStringField("url", requestedUrl);
+        }
+
+        private String firstLineOfRequest(IAccessEvent event) {
+            // This method is *terribly* named. It doesn't return a URL at all, but
+            // rather the first line of the HTTP request.  For example, it might
+            // return "GET /foo/bar?baz HTTP/1.1".
+            // This method exists purely to give it a less confusing name
+            return event.getRequestURL();
+        }
+    }
+
+    public static class RemoteIpJsonProvider extends AbstractJsonProvider<IAccessEvent> {
+        @Override
+        public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
+            generator.writeStringField("remote_ip", event.getRemoteAddr());
+        }
     }
 }

--- a/src/main/java/uk/gov/ida/dropwizard/logstash/typed/BytesField.java
+++ b/src/main/java/uk/gov/ida/dropwizard/logstash/typed/BytesField.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.dropwizard.logstash.typed;
+
+public class BytesField {
+    public final long bytes;
+
+    public BytesField(long bytes) {
+        this.bytes = bytes;
+    }
+}

--- a/src/main/java/uk/gov/ida/dropwizard/logstash/typed/MillisecondsField.java
+++ b/src/main/java/uk/gov/ida/dropwizard/logstash/typed/MillisecondsField.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.dropwizard.logstash.typed;
+
+public class MillisecondsField {
+    public final long ms;
+
+    public MillisecondsField(long ms) {
+        this.ms = ms;
+    }
+}

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
@@ -46,7 +46,7 @@ public class LogstashConsoleAppenderAppRuleTest {
         final List<AccessEventFormat> list = parseLogsOfType(AccessEventFormat.class);
 
         List<AccessEventFormat> accessEventStream = list.stream().filter(accessLog -> accessLog.getMethod().equals("GET")).collect(toList());
-        assertThat(accessEventStream.size()).isEqualTo(1);
+        assertThat(accessEventStream.size()).as("check there's an access log in the following:\n%s", systemOutRule.getLog()).isEqualTo(1);
         AccessEventFormat accessEvent = accessEventStream.get(0);
         assertThat(accessEvent.getMethod()).isEqualTo("GET");
         assertThat(accessEvent.getBytesSent()).isEqualTo("hello!".length());

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
@@ -43,7 +43,11 @@ public class LogstashConsoleAppenderAppRuleTest {
 
         assertThat(response.readEntity(String.class)).isEqualTo("hello!");
 
-        System.out.flush();
+        // If we try to read systemOutRule too quickly, under some circumstances the appender won't have
+        // successfully written the expected access log line yet.  We haven't got to the bottom of this
+        // but it seems to depend on whether another DropwizardAppRule test has been run before this one.
+        // sleeping for a while fixes the problem
+        Thread.sleep(500);
 
         final List<AccessEventFormat> list = parseLogsOfType(AccessEventFormat.class);
 

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
@@ -39,7 +39,7 @@ public class LogstashConsoleAppenderAppRuleTest {
     public void testLoggingLogstashRequestLog() throws InterruptedException, IOException {
         Client client = new JerseyClientBuilder().build();
 
-        final Response response = client.target("http://localhost:" + dropwizardAppRule.getLocalPort() + "/").request().get();
+        final Response response = client.target("http://localhost:" + dropwizardAppRule.getLocalPort() + "/?queryparam=test").request().get();
 
         assertThat(response.readEntity(String.class)).isEqualTo("hello!");
 
@@ -49,11 +49,15 @@ public class LogstashConsoleAppenderAppRuleTest {
         assertThat(accessEventStream.size()).isEqualTo(1);
         AccessEventFormat accessEvent = accessEventStream.get(0);
         assertThat(accessEvent.getMethod()).isEqualTo("GET");
-        assertThat(accessEvent.getContentLength()).isEqualTo("hello!".length());
-        assertThat(accessEvent.getRequestedUri()).isEqualTo("/");
-        assertThat(accessEvent.getProtocol()).isEqualTo("HTTP/1.1");
-        assertThat(accessEvent.getStatusCode()).isEqualTo(200);
+        assertThat(accessEvent.getBytesSent()).isEqualTo("hello!".length());
+        assertThat(accessEvent.getUrl()).isEqualTo("/?queryparam=test");
+        assertThat(accessEvent.getHttpVersion()).isEqualTo("1.1");
+        assertThat(accessEvent.getResponseCode()).isEqualTo(200);
+        assertThat(accessEvent.getRemoteIp()).isEqualTo("127.0.0.1");
         assertThat(accessEvent.getVersion()).isEqualTo(1);
+        // ballpark check that the unit is in the right order of magnitude
+        // this test should hopefully catch a value that's erroneously measured in seconds
+        assertThat(accessEvent.getElapsedTimeMillis()).isBetween(3,3000);
     }
 
     @Test

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
@@ -43,6 +43,8 @@ public class LogstashConsoleAppenderAppRuleTest {
 
         assertThat(response.readEntity(String.class)).isEqualTo("hello!");
 
+        System.out.flush();
+
         final List<AccessEventFormat> list = parseLogsOfType(AccessEventFormat.class);
 
         List<AccessEventFormat> accessEventStream = list.stream().filter(accessLog -> accessLog.getMethod().equals("GET")).collect(toList());

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/support/AccessEventFormat.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/support/AccessEventFormat.java
@@ -3,6 +3,12 @@ package uk.gov.ida.dropwizard.logstash.support;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AccessEventFormat {
+    public static class Bytes {
+        public int bytes;
+    }
+    public static class Milliseconds {
+        public int ms;
+    }
 
     @JsonProperty("@timestamp")
     public String timestamp;
@@ -10,16 +16,20 @@ public class AccessEventFormat {
     @JsonProperty("@version")
     public int version;
 
-    public int content_length;
-    public int elapsed_time;
-    public String hostname;
-    public String method;
-    public String protocol;
-    public String remote_host;
-    public String remote_user;
-    public String requested_uri;
-    public int status_code;
     public String message;
+
+    public AccessData access;
+
+    public static class AccessData {
+        public Bytes body_sent;
+        public Milliseconds elapsed_time;
+        public String method;
+        public String http_version;
+        public String remote_ip;
+        public String user_name;
+        public int response_code;
+        public String url;
+    }
 
     private AccessEventFormat() {
 
@@ -38,40 +48,36 @@ public class AccessEventFormat {
         return version;
     }
 
-    public int getContentLength() {
-        return content_length;
+    public int getBytesSent() {
+        return access.body_sent.bytes;
     }
 
-    public int getElapsedTime() {
-        return elapsed_time;
-    }
-
-    public String getHostname() {
-        return hostname;
+    public int getElapsedTimeMillis() {
+        return access.elapsed_time.ms;
     }
 
     public String getMethod() {
-        return method;
+        return access.method;
     }
 
-    public String getProtocol() {
-        return protocol;
+    public String getHttpVersion() {
+        return access.http_version;
     }
 
-    public String getRemoteHost() {
-        return remote_host;
+    public String getRemoteIp() {
+        return access.remote_ip;
     }
 
-    public String getRemoteUser() {
-        return remote_user;
+    public String getUserName() {
+        return access.user_name;
     }
 
-    public String getRequestedUri() {
-        return requested_uri;
+    public int getResponseCode() {
+        return access.response_code;
     }
 
-    public int getStatusCode() {
-        return status_code;
+    public String getUrl() {
+        return access.url;
     }
 
     public String getMessage() {


### PR DESCRIPTION
This commit changes the field names and values to be more consistent
with other logging technologies.  For this, I have drawn prior art
from:

  - the libbeat naming conventions:
    https://www.elastic.co/guide/en/beats/libbeat/current/event-conventions.html
  - the filebeat apache2 and nginx module field names:
    https://www.elastic.co/guide/en/beats/filebeat/current/exported-fields-apache2.html
    https://www.elastic.co/guide/en/beats/filebeat/current/exported-fields-nginx.html

The changes, in full, are:

0. things left alone

  - the top-level `message` field is left as-is
  - `method` is left as-is

1. simple renames

  - `content_length` is now `body_sent.bytes`
    - the actual value hasn't changed, but the new name is clearer
      that it reflects the actual number of bytes sent, not the value
      of the Content-length header
  - `elapsed_time` is now `elapsed_time.ms`
  - `remote_user` is now `user_name`
  - `status_code` is now `response_code`

2. subtle changes

  - `protocol` is now `http_version`.  It used to have a value such as
    "HTTP/1.1", but now is truncated to merely "1.1".
  - `remote_host` is now `remote_ip`.  It used to call getRemoteHost()
    which has a documented possibility of actually being a
    hostname (after a reverse DNS lookup, presumably); it now calls
    getRemoteAddr() which is definitely just an IP address.
  - `hostname` has been removed.  If you look at the implementation of
    HostnameJsonProvider, it just called event.getRemoteHost(), so had
    exactly the same value as `remote_host` but a more confusing name.

3. bigger changes

  - `requested_uri` is replaced by `url`.  However, `requested_uri`
    was confusing in that it omitted the query string.  There was
    nothing which provided the query string before this commit.  The
    new `url` field is the relative URL, including path and query
    string, as extracted from the first line of the request.

Note here that the easy-to-use IAccessEvent.getRequestedURI() and
IAccessEvent.getRequestedURL() methods are both problematic:

   - IAccessEvent.getRequestedURI() returns a path, not a URI.  In
     particular, it's missing the query string.
   - IAccessEvent.getRequestedURL() returns the first line of the HTTP
     request, not a URL.  In particular, it returns something like
     "GET /foo/bar?baz HTTP/1.1"

For something to be called "URI" or "URL" it should have the full path
and query string.  This matches filebeat's
`{apache2,nginx}.access.url` fields.

----

You might be wondering why we now instantiate an anonymous subclass of
AbstractNestedJsonProvider.  It's because we don't need any of the
functionality provided by subclasses like
AccessEventNestedJsonProvider; the superclass provides all the
functionality we need.  It can't be instantiated because it's
abstract, even though it has no abstract methods.

So we instantiate an anonymous inner class with an empty body.