### PR TITLE
Add extra fields

### DIFF
--- a/src/main/java/uk/gov/ida/dropwizard/logstash/AccessLogstashConsoleAppenderFactory.java
+++ b/src/main/java/uk/gov/ida/dropwizard/logstash/AccessLogstashConsoleAppenderFactory.java
@@ -79,6 +79,7 @@ public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory
             accessProviders.addProvider(new MethodJsonProvider() {{setFieldName("method");}});
             accessProviders.addProvider(new HttpVersionJsonProvider());
             accessProviders.addProvider(new RefererJsonProvider());
+            accessProviders.addProvider(new UserAgentJsonProvider());
             accessProviders.addProvider(new StatusCodeJsonProvider() {{setFieldName("response_code");}});
             accessProviders.addProvider(new UrlJsonProvider());
             accessProviders.addProvider(new RemoteIpJsonProvider());
@@ -141,6 +142,13 @@ public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory
         @Override
         public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
             generator.writeStringField("referrer", event.getRequestHeader("Referer"));
+        }
+    }
+
+    public static class UserAgentJsonProvider extends AbstractJsonProvider<IAccessEvent> {
+        @Override
+        public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
+            generator.writeStringField("agent", event.getRequestHeader("User-Agent"));
         }
     }
 }

--- a/src/main/java/uk/gov/ida/dropwizard/logstash/AccessLogstashConsoleAppenderFactory.java
+++ b/src/main/java/uk/gov/ida/dropwizard/logstash/AccessLogstashConsoleAppenderFactory.java
@@ -80,6 +80,7 @@ public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory
             accessProviders.addProvider(new HttpVersionJsonProvider());
             accessProviders.addProvider(new RefererJsonProvider());
             accessProviders.addProvider(new UserAgentJsonProvider());
+            accessProviders.addProvider(new HostJsonProvider());
             accessProviders.addProvider(new StatusCodeJsonProvider() {{setFieldName("response_code");}});
             accessProviders.addProvider(new UrlJsonProvider());
             accessProviders.addProvider(new RemoteIpJsonProvider());
@@ -149,6 +150,13 @@ public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory
         @Override
         public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
             generator.writeStringField("agent", event.getRequestHeader("User-Agent"));
+        }
+    }
+
+    public static class HostJsonProvider extends AbstractJsonProvider<IAccessEvent> {
+        @Override
+        public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
+            generator.writeStringField("host", event.getRequestHeader("Host"));
         }
     }
 }

--- a/src/main/java/uk/gov/ida/dropwizard/logstash/AccessLogstashConsoleAppenderFactory.java
+++ b/src/main/java/uk/gov/ida/dropwizard/logstash/AccessLogstashConsoleAppenderFactory.java
@@ -78,6 +78,7 @@ public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory
             JsonProviders<IAccessEvent> accessProviders = access.getProviders();
             accessProviders.addProvider(new MethodJsonProvider() {{setFieldName("method");}});
             accessProviders.addProvider(new HttpVersionJsonProvider());
+            accessProviders.addProvider(new RefererJsonProvider());
             accessProviders.addProvider(new StatusCodeJsonProvider() {{setFieldName("response_code");}});
             accessProviders.addProvider(new UrlJsonProvider());
             accessProviders.addProvider(new RemoteIpJsonProvider());
@@ -133,6 +134,13 @@ public class AccessLogstashConsoleAppenderFactory extends ConsoleAppenderFactory
         @Override
         public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
             generator.writeStringField("remote_ip", event.getRemoteAddr());
+        }
+    }
+
+    public static class RefererJsonProvider extends AbstractJsonProvider<IAccessEvent> {
+        @Override
+        public void writeTo(JsonGenerator generator, IAccessEvent event) throws IOException {
+            generator.writeStringField("referrer", event.getRequestHeader("Referer"));
         }
     }
 }

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.RuleChain;
@@ -28,10 +28,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LogstashConsoleAppenderAppRuleTest {
 
     public static DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(TestApplication.class, ResourceHelpers.resourceFilePath("console-appender-test-application.yml"));
-    public static SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
 
-    @ClassRule
-    public static TestRule ruleChain = RuleChain
+    @Rule
+    public TestRule ruleChain = RuleChain
             .outerRule(systemOutRule)
             .around(dropwizardAppRule);
 
@@ -68,6 +68,29 @@ public class LogstashConsoleAppenderAppRuleTest {
         // ballpark check that the unit is in the right order of magnitude
         // this test should hopefully catch a value that's erroneously measured in seconds
         assertThat(accessEvent.getElapsedTimeMillis()).isBetween(3,3000);
+    }
+
+    @Test
+    public void testRequestLogWithMissingRefererHeader() throws InterruptedException, IOException {
+        Client client = new JerseyClientBuilder().build();
+
+        final Response response = client.target("http://localhost:" + dropwizardAppRule.getLocalPort() + "/").request()
+                .get();
+
+        assertThat(response.readEntity(String.class)).isEqualTo("hello!");
+
+        // If we try to read systemOutRule too quickly, under some circumstances the appender won't have
+        // successfully written the expected access log line yet.  We haven't got to the bottom of this
+        // but it seems to depend on whether another DropwizardAppRule test has been run before this one.
+        // sleeping for a while fixes the problem
+        Thread.sleep(500);
+
+        final List<AccessEventFormat> list = parseLogsOfType(AccessEventFormat.class);
+
+        List<AccessEventFormat> accessEventStream = list.stream().filter(accessLog -> accessLog.getMethod().equals("GET")).collect(toList());
+        assertThat(accessEventStream.size()).as("check there's an access log in the following:\n%s", systemOutRule.getLog()).isEqualTo(1);
+        AccessEventFormat accessEvent = accessEventStream.get(0);
+        assertThat(accessEvent.getReferer()).isEqualTo("-");
     }
 
     @Test

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
@@ -39,7 +39,8 @@ public class LogstashConsoleAppenderAppRuleTest {
     public void testLoggingLogstashRequestLog() throws InterruptedException, IOException {
         Client client = new JerseyClientBuilder().build();
 
-        final Response response = client.target("http://localhost:" + dropwizardAppRule.getLocalPort() + "/?queryparam=test").request().get();
+        final Response response = client.target("http://localhost:" + dropwizardAppRule.getLocalPort() + "/?queryparam=test").request()
+                .header("Referer", "http://foobar/").get();
 
         assertThat(response.readEntity(String.class)).isEqualTo("hello!");
 
@@ -55,6 +56,7 @@ public class LogstashConsoleAppenderAppRuleTest {
         assertThat(accessEventStream.size()).as("check there's an access log in the following:\n%s", systemOutRule.getLog()).isEqualTo(1);
         AccessEventFormat accessEvent = accessEventStream.get(0);
         assertThat(accessEvent.getMethod()).isEqualTo("GET");
+        assertThat(accessEvent.getReferer()).isEqualTo("http://foobar/");
         assertThat(accessEvent.getBytesSent()).isEqualTo("hello!".length());
         assertThat(accessEvent.getUrl()).isEqualTo("/?queryparam=test");
         assertThat(accessEvent.getHttpVersion()).isEqualTo("1.1");

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
@@ -58,6 +58,7 @@ public class LogstashConsoleAppenderAppRuleTest {
         assertThat(accessEvent.getMethod()).isEqualTo("GET");
         assertThat(accessEvent.getReferer()).isEqualTo("http://foobar/");
         assertThat(accessEvent.getUserAgent()).isEqualTo("lynx/1.337");
+        assertThat(accessEvent.getHost()).startsWith("localhost");
         assertThat(accessEvent.getBytesSent()).isEqualTo("hello!".length());
         assertThat(accessEvent.getUrl()).isEqualTo("/?queryparam=test");
         assertThat(accessEvent.getHttpVersion()).isEqualTo("1.1");

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/LogstashConsoleAppenderAppRuleTest.java
@@ -40,7 +40,7 @@ public class LogstashConsoleAppenderAppRuleTest {
         Client client = new JerseyClientBuilder().build();
 
         final Response response = client.target("http://localhost:" + dropwizardAppRule.getLocalPort() + "/?queryparam=test").request()
-                .header("Referer", "http://foobar/").get();
+                .header("Referer", "http://foobar/").header("User-Agent","lynx/1.337").get();
 
         assertThat(response.readEntity(String.class)).isEqualTo("hello!");
 
@@ -57,6 +57,7 @@ public class LogstashConsoleAppenderAppRuleTest {
         AccessEventFormat accessEvent = accessEventStream.get(0);
         assertThat(accessEvent.getMethod()).isEqualTo("GET");
         assertThat(accessEvent.getReferer()).isEqualTo("http://foobar/");
+        assertThat(accessEvent.getUserAgent()).isEqualTo("lynx/1.337");
         assertThat(accessEvent.getBytesSent()).isEqualTo("hello!".length());
         assertThat(accessEvent.getUrl()).isEqualTo("/?queryparam=test");
         assertThat(accessEvent.getHttpVersion()).isEqualTo("1.1");

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/support/AccessEventFormat.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/support/AccessEventFormat.java
@@ -31,6 +31,7 @@ public class AccessEventFormat {
         public String url;
         public String referrer;
         public String agent;
+        public String host;
     }
 
     private AccessEventFormat() {
@@ -60,6 +61,10 @@ public class AccessEventFormat {
 
     public String getUserAgent() {
         return access.agent;
+    }
+
+    public String getHost() {
+        return access.host;
     }
 
     public int getElapsedTimeMillis() {

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/support/AccessEventFormat.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/support/AccessEventFormat.java
@@ -30,6 +30,7 @@ public class AccessEventFormat {
         public int response_code;
         public String url;
         public String referrer;
+        public String agent;
     }
 
     private AccessEventFormat() {
@@ -55,6 +56,10 @@ public class AccessEventFormat {
 
     public String getReferer() {
         return access.referrer;
+    }
+
+    public String getUserAgent() {
+        return access.agent;
     }
 
     public int getElapsedTimeMillis() {

--- a/src/test/java/uk/gov/ida/dropwizard/logstash/support/AccessEventFormat.java
+++ b/src/test/java/uk/gov/ida/dropwizard/logstash/support/AccessEventFormat.java
@@ -29,6 +29,7 @@ public class AccessEventFormat {
         public String user_name;
         public int response_code;
         public String url;
+        public String referrer;
     }
 
     private AccessEventFormat() {
@@ -50,6 +51,10 @@ public class AccessEventFormat {
 
     public int getBytesSent() {
         return access.body_sent.bytes;
+    }
+
+    public String getReferer() {
+        return access.referrer;
     }
 
     public int getElapsedTimeMillis() {


### PR DESCRIPTION
This adds the `referrer`, `agent` and `host` fields to the JSON output.  They come from the `Referer`, `User-Agent` and `Host` request headers, respectively.