### PR TITLE
49: Upgrade Dropwizard to 1.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard: '1.2.2'
+        dropwizard: '1.3.5'
 ]
 
 dependencies {


### PR DESCRIPTION
Upgrade Dropwizard to 1.3.5 to fix various security issues.

Authors: @adityapahuja