### PR TITLE
BAU: Make lib use same Jcenter repo as other libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ bintray {
     publications = ['mavenJava']
     publish = true
     pkg {
-        repo = 'maven'
+        repo = 'maven-test'
         name = 'dropwizard-logstash'
         userOrg = 'alphagov'
         licenses = ['MIT']


### PR DESCRIPTION
- We use maven-test for our public libs