### PR TITLE
BAU Bump dropwizard to 1.3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard: '1.3.5'
+        dropwizard: '1.3.9'
 ]
 
 dependencies {


### PR DESCRIPTION
This brings it in line with the hub and fixes a number of security
vulnerabilities.