### PR TITLE
BAU Upgrade dropwizard to 1.3.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard: '1.3.9'
+        dropwizard: '1.3.12'
 ]
 
 dependencies {


### PR DESCRIPTION
A few vulnerabilities were found in 1.3.9 which were affecting downstream
projects (Verify event emitter).

[CVE-2019-10247](https://snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174560)
[CVE-2019-12086](https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-174736)