### PR TITLE
Bau - Allow gradle to publish to bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,8 @@ test {
     }
 }
 
-
 task sourceJar(type: Jar) {
-    classifier "sources"
+    archiveClassifier = "sources"
     from sourceSets.main.allJava
 }
 
@@ -103,4 +102,3 @@ idea {
         downloadSources = true
     }
 }
-


### PR DESCRIPTION
- Due to the upgrade of gradle, the MavenPublication behaves slightly different
so needs to be changed.