### PR TITLE
BAU: Use OpenJDK to run Java 8 build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   - $HOME/.gradle/wrapper
   - $HOME/.m2
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 after_success:
 - test "$TRAVIS_PULL_REQUEST" == false && test -n "$TRAVIS_TAG" && BUILD_NUMBER=$TRAVIS_TAG


### PR DESCRIPTION
Travis no longer supports Oracle Java 8 JDK