### PR TITLE
BAU: Fix dropwizard version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard: '2.0.2'
+        dropwizard: '1.3.20'
 ]
 
 group 'uk.gov.ida'


### PR DESCRIPTION
Dropwizard 2.0.2 was cuasing issues in the proxy node.
Version 1.3.20 we stop this. No reason for using 2.0.+