### PR TITLE
HUB-942: Bump dropwizard to 2.0.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard: '1.3.22'
+        dropwizard: '2.0.21'
 ]
 
 group 'uk.gov.ida'
@@ -33,7 +33,8 @@ dependencies {
             'org.hamcrest:hamcrest-library:2.2',
             'org.mockito:mockito-core:3.2.0',
             'com.github.stefanbirkner:system-rules:1.16.1',
-            "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizard"
+            "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizard",
+            'org.assertj:assertj-core:3.19.0'
 }
 
 sourceSets {


### PR DESCRIPTION
Doing this seems to lose a transitive dependency on assertj, so it's
been explicitly added.