### PR TITLE
BAU - Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 100
+

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard: '2.0.21'
+        dropwizard: '2.1.2'
 ]
 
 group 'uk.gov.ida'


### PR DESCRIPTION
 - Enable dependabot so we can keep up to date with the latest dependencies 
 - Update dropwizard to the latest version 2 version '2.1.2'