### PR TITLE
Mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # dropwizard-logstash
 
-[![Build Status](https://travis-ci.org/alphagov/dropwizard-logstash.svg?branch=master)](https://travis-ci.org/alphagov/dropwizard-logstash)
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
 
 Dropwizard extension that supports logstash format with various appenders: `logstash-file`, `logstash-syslog`, `logstash-console`
 


### PR DESCRIPTION
Update README.md to mark repo as archived

As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.